### PR TITLE
fix: deps bump, Bedrock Messages API migration, deploy script, Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Perfect for GRC professionals managing SOC 2 Type 2 and similar compliance frame
    - `--schedule`: Schedule expression for running the review (default: rate(30 days))
    - `--profile`: AWS CLI profile to use for credentials (default: uses default profile)
 
+   **Windows users**: a PowerShell port of the deploy path is provided at `scripts/deploy.ps1`. Run it from PowerShell instead of the bash script:
+   ```powershell
+   ./scripts/deploy.ps1 -Email your.email@example.com -Profile your-aws-profile
+   ```
+   The other helper scripts (`check_aws_creds.sh`, `run_report.sh`, `cleanup.sh`, etc.) remain bash-only — run those from WSL or Git Bash.
+
 5. **⚠️ IMPORTANT: Verify your email address by clicking the link in the verification email sent by AWS SES before proceeding!**
 
 6. Run an immediate access review report:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,15 @@
 # Runtime dependencies
-boto3>=1.28.0
+# boto3 1.34+ ships a stable bedrock-runtime client with the Anthropic Messages API.
+# The Lambda python3.11 runtime bundles its own boto3, so we leave the upper bound open.
+boto3>=1.34.0
 
 # Testing dependencies
 pytest>=7.3.1
 pytest-mock>=3.10.0
 pytest-cov>=4.0.0
 pytest-timeout>=2.0.0
-moto>=4.1.12
+# moto 5.x introduced breaking mock API changes; pin the floor so tests resolve the right version
+moto>=5.0.0
 
 # Code quality
 flake8>=6.0.0

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -1,0 +1,83 @@
+# PowerShell port of scripts/deploy.sh for Windows users.
+# Requires: AWS CLI v2, PowerShell 5.1+ (or PowerShell 7+), Compress-Archive (built-in).
+
+[CmdletBinding()]
+param(
+    [string]$StackName = "aws-access-review",
+    [string]$Region = "us-east-1",
+    [string]$Schedule = "rate(30 days)",
+    [Parameter(Mandatory = $true)]
+    [string]$Email,
+    [string]$Profile = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$awsCommonArgs = @("--region", $Region)
+if ($Profile) {
+    $awsCommonArgs += @("--profile", $Profile)
+    Write-Host "Using AWS profile: $Profile"
+}
+
+Write-Host "Verifying AWS credentials..."
+& aws sts get-caller-identity @awsCommonArgs | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Unable to validate AWS credentials. Check your AWS configuration or profile."
+}
+Write-Host "AWS credentials verified."
+
+Write-Host "Preparing deployment files..."
+if (Test-Path "deployment") { Remove-Item -Recurse -Force "deployment" }
+New-Item -ItemType Directory -Path "deployment" | Out-Null
+
+Copy-Item -Path "src/lambda/*" -Destination "deployment/" -Recurse -Force
+
+# Strip compiled artifacts so the zip is reproducible
+Get-ChildItem -Path "deployment" -Recurse -Directory -Filter "__pycache__" |
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+Get-ChildItem -Path "deployment" -Recurse -Filter "*.pyc" |
+    Remove-Item -Force -ErrorAction SilentlyContinue
+
+Write-Host "Creating Lambda deployment package..."
+if (Test-Path "lambda_function.zip") { Remove-Item -Force "lambda_function.zip" }
+Compress-Archive -Path "deployment/*" -DestinationPath "lambda_function.zip" -Force
+
+Write-Host "Deploying CloudFormation stack '$StackName' to region '$Region'..."
+$deployArgs = @(
+    "cloudformation", "deploy",
+    "--template-file", "templates/access-review-real.yaml",
+    "--stack-name", $StackName,
+    "--parameter-overrides", "RecipientEmail=$Email", "ScheduleExpression=$Schedule",
+    "--capabilities", "CAPABILITY_IAM",
+    "--no-fail-on-empty-changeset"
+) + $awsCommonArgs
+& aws @deployArgs
+if ($LASTEXITCODE -ne 0) { throw "CloudFormation deploy failed." }
+
+Write-Host "Getting S3 bucket name from CloudFormation stack..."
+$bucketName = & aws cloudformation describe-stacks `
+    --stack-name $StackName @awsCommonArgs `
+    --query "Stacks[0].Outputs[?OutputKey=='AccessReviewS3Bucket'].OutputValue" `
+    --output text
+
+Write-Host "Getting Lambda function ARN from CloudFormation stack..."
+$lambdaArn = & aws cloudformation describe-stacks `
+    --stack-name $StackName @awsCommonArgs `
+    --query "Stacks[0].Outputs[?OutputKey=='AccessReviewLambdaArn'].OutputValue" `
+    --output text
+
+Write-Host "Updating Lambda function code..."
+& aws lambda update-function-code `
+    --function-name $lambdaArn `
+    --zip-file fileb://lambda_function.zip `
+    @awsCommonArgs | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "Lambda update-function-code failed." }
+
+Write-Host ""
+Write-Host "Deployment completed successfully!"
+Write-Host "Lambda function: $lambdaArn"
+Write-Host "S3 bucket for reports: $bucketName"
+Write-Host "Recipient email: $Email"
+Write-Host "Schedule: $Schedule"
+Write-Host ""
+Write-Host "IMPORTANT: If this is a first-time deployment, verify your email address via the SES verification email."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -64,13 +64,18 @@ echo "Preparing deployment files..."
 rm -rf deployment
 mkdir -p deployment
 
-# Copy all Lambda files from src to deployment
-cp -r src/lambda/* deployment/
+# Copy all Lambda files from src to deployment, then strip compiled artifacts
+# so the zip is reproducible and doesn't bundle local interpreter state.
+cp -r src/lambda/. deployment/
+find deployment -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+find deployment -type f -name "*.pyc" -delete 2>/dev/null || true
 
-# Package Lambda function
+# Package Lambda function. Remove any stale zip first so `zip -r` does not
+# append to an existing archive (which produces a broken Lambda bundle).
 echo "Creating Lambda deployment package..."
+rm -f lambda_function.zip
 cd deployment
-zip -r ../lambda_function.zip .
+zip -r -X ../lambda_function.zip . >/dev/null
 cd ..
 
 # Create/Update the CloudFormation stack
@@ -82,6 +87,7 @@ aws cloudformation deploy \
     RecipientEmail="$EMAIL" \
     ScheduleExpression="$SCHEDULE" \
   --capabilities CAPABILITY_IAM \
+  --no-fail-on-empty-changeset \
   --region "$REGION" \
   $AWS_CMD_PROFILE
 

--- a/src/lambda/bedrock_integration.py
+++ b/src/lambda/bedrock_integration.py
@@ -22,6 +22,7 @@ Last Updated: 2025-04-01
 """
 
 import json  # For parsing and formatting API requests/responses
+import os  # For reading BEDROCK_MODEL_ID override
 import boto3  # AWS SDK for Python to interact with Amazon Bedrock
 
 
@@ -238,36 +239,43 @@ def invoke_claude_model(bedrock, prompt):
         - Max tokens: Limits response length (4096 provides detailed but concise analysis)
         - Top-p: Controls diversity of responses (0.9 is a balanced setting)
     """
-    # Step 1: Select model and set parameters
-    # Using Claude v2 for comprehensive text generation capabilities
-    model_id = "anthropic.claude-v2"  # Amazon Bedrock model identifier
+    # Step 1: Select model and set parameters.
+    # Claude v2 was retired on Bedrock; use the current Claude 3.5 Sonnet model ID.
+    # Override via the BEDROCK_MODEL_ID env var if the caller's region needs a different
+    # model (e.g. cross-region inference profile, different generation).
+    model_id = os.environ.get(
+        "BEDROCK_MODEL_ID", "anthropic.claude-3-5-sonnet-20240620-v1:0"
+    )
 
-    # Step 2: Construct the complete prompt with instructions
-    # The prompt follows Claude's required Human/Assistant format
-    # and includes specific instructions for security report generation
+    # Step 2: Build the Anthropic Messages API request body.
+    # Claude v2's text-completion format ("prompt" + "max_tokens_to_sample") is
+    # not accepted by Claude 3.x models — they require the messages schema.
+    system_message = (
+        "You are a cybersecurity expert analyzing AWS security findings. "
+        "Generate concise, professional security reports suitable for both "
+        "technical and non-technical stakeholders."
+    )
+    user_message = (
+        f"{prompt}\n\n"
+        "Your report should include:\n"
+        "1. An executive summary of the security posture\n"
+        "2. Analysis of the most critical findings\n"
+        "3. Clear, actionable recommendations\n"
+        "4. Compliance implications\n\n"
+        "Format the report with clear headings and concise language."
+    )
     request_body = {
-        "prompt": (
-            # Begin with Claude's expected format
-            "\n\nHuman: You are a cybersecurity expert analyzing AWS security findings. "
-            "Generate a concise, professional security report based on the following "
-            f"findings:\n\n{prompt}\n\n"
-            # Specific instructions for report structure
-            "Your report should include:\n"
-            "1. An executive summary of the security posture\n"
-            "2. Analysis of the most critical findings\n"
-            "3. Clear, actionable recommendations\n"
-            "4. Compliance implications\n\n"
-            # Style guidance for the report
-            "Format the report with clear headings and concise language suitable for both "
-            "technical and non-technical stakeholders.\n\n"
-            # Claude's expected assistant prefix
-            "Assistant: I'll analyze the findings and provide a comprehensive security "
-            "report.\n\n"
-        ),
-        # Model configuration parameters
-        "max_tokens_to_sample": 4096,  # Maximum response length (roughly 3000 words)
-        "temperature": 0.7,  # Balances creativity and consistency
-        "top_p": 0.9,  # Controls diversity of word selection
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 4096,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "system": system_message,
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": user_message}],
+            }
+        ],
     }
 
     # Step 3: Call the Bedrock API
@@ -306,12 +314,17 @@ def extract_narrative_claude(response):
         process isn't blocked.
     """
     try:
-        # For Claude model, the generated text is in the "completion" field
-        # We strip any extra whitespace to ensure clean formatting
-        narrative = response.get("completion", "")
-
-        # Apply any additional formatting or post-processing here if needed
-        # For example, we might want to add a title, fix formatting issues, etc.
+        # Claude 3.x Messages API: the generated text is in
+        # response["content"][0]["text"]. Support the legacy "completion" field
+        # too so callers mocking the old shape keep working.
+        if "content" in response and isinstance(response["content"], list):
+            narrative = "".join(
+                block.get("text", "")
+                for block in response["content"]
+                if block.get("type") == "text"
+            )
+        else:
+            narrative = response.get("completion", "")
 
         return narrative.strip()
 

--- a/tests/unit/test_bedrock_integration.py
+++ b/tests/unit/test_bedrock_integration.py
@@ -66,9 +66,10 @@ class TestClaudeModelIntegration(unittest.TestCase):
         mock_bedrock = MagicMock()
         mock_boto3_client.return_value = mock_bedrock
 
-        # Mock the response from Bedrock
+        # Mock the response from Bedrock using the Messages API shape
         mock_response = {
-            "completion": "This is a test narrative.",
+            "content": [{"type": "text", "text": "This is a test narrative."}],
+            "stop_reason": "end_turn",
         }
         mock_bedrock.invoke_model.return_value = {
             "body": MagicMock(
@@ -84,15 +85,27 @@ class TestClaudeModelIntegration(unittest.TestCase):
         self.assertEqual(response, mock_response)
         mock_bedrock.invoke_model.assert_called_once()
 
+        # Verify the request body uses the Messages API, not legacy completion
+        call_kwargs = mock_bedrock.invoke_model.call_args.kwargs
+        body = json.loads(call_kwargs["body"])
+        self.assertEqual(body["anthropic_version"], "bedrock-2023-05-31")
+        self.assertEqual(body["max_tokens"], 4096)
+        self.assertIn("messages", body)
+        self.assertNotIn("max_tokens_to_sample", body)
+        self.assertNotIn("prompt", body)
+        # Default model ID should be a Claude 3.x variant
+        self.assertIn("claude-3", call_kwargs["modelId"])
+
 
 class TestNarrativeExtraction(unittest.TestCase):
     """Test the narrative extraction function."""
 
     def test_extract_narrative_claude(self):
-        """Test the extract_narrative_claude function."""
-        # Sample response from Claude model
+        """Test the extract_narrative_claude function with the Messages API shape."""
+        # Claude 3.x Messages API response
         response = {
-            "completion": "This is a test narrative.",
+            "content": [{"type": "text", "text": "This is a test narrative."}],
+            "stop_reason": "end_turn",
         }
 
         # Call the function
@@ -100,6 +113,14 @@ class TestNarrativeExtraction(unittest.TestCase):
 
         # Assertions
         self.assertEqual(narrative, "This is a test narrative.")
+
+    def test_extract_narrative_claude_legacy_completion(self):
+        """Back-compat: legacy text-completion responses still extract cleanly."""
+        response = {"completion": "Legacy narrative."}
+        self.assertEqual(
+            bedrock_integration.extract_narrative_claude(response),
+            "Legacy narrative.",
+        )
 
 
 class TestFallbackNarrative(unittest.TestCase):


### PR DESCRIPTION
## Summary

Four focused fixes triaged after cloning cold and running the test/lint/CFN suites against current tool versions. Each commit is self-contained.

- **Deps (be7686c)** — bump `boto3>=1.34.0` and `moto>=5.0.0`. The old `boto3>=1.28.0` floor predated the stable `bedrock-runtime` Messages API support we now depend on; moto 5.x has breaking mock API changes from 4.x so the floor is moved to match the code.
- **Bedrock Messages API (9e77d23)** — `bedrock_integration.py` targeted retired `anthropic.claude-v2` with the legacy text-completion schema (`prompt` + `max_tokens_to_sample`, `completion` response field). Migrated to `anthropic.claude-3-5-sonnet-20240620-v1:0` with a `BEDROCK_MODEL_ID` env override, rebuilt the request body around the messages schema, and extract text from `response.content[*].text`. Back-compat path kept for the legacy `completion` field. Tests updated to assert the new request shape and cover both response formats.
- **deploy.sh (f72fdf9)** — three small but real bugs in the Lambda packaging path: dotfiles were skipped by `cp -r src/lambda/*`, dev-machine `__pycache__` and `.pyc` files were bundled into the zip, and a stale `lambda_function.zip` would be appended to rather than replaced. Also adds `--no-fail-on-empty-changeset` so code-only redeploys don't abort.
- **Windows support (98d2991)** — new `scripts/deploy.ps1` mirrors `deploy.sh` for the primary deploy path (Compress-Archive + argument splatting). README now points Windows users to the `.ps1` and is explicit that the other helper scripts remain bash-only (WSL / Git Bash).

## What was verified locally

- `pytest tests/unit --timeout=30` — **15/15 pass** (was 14, added a back-compat extraction test).
- `flake8 src/ tests/` — clean.
- `black --check src/ tests/` — clean.
- `cfn-lint templates/*.yaml` — clean.
- `aws cloudformation validate-template --template-body file://templates/access-review-real.yaml` — valid.
- `bash -n scripts/deploy.sh` — syntax clean.

## What was NOT done (deliberately)

- Did not run `deploy.sh` against a live AWS account — that creates real resources and costs money; held for owner review.
- `deploy.ps1` was not executed on a Windows host (no `pwsh` locally). Syntax is consistent with PS 5.1+.
- PR #1 (attack simulation from @mnichols936) is untouched — separate scope.

## Test plan

- [ ] CI on this PR branch passes
- [ ] Reviewer runs `bash scripts/deploy.sh --email <verified-ses-address>` against a sandbox account and confirms stack deploys and Lambda zip loads
- [ ] Reviewer (optional) runs `pwsh ./scripts/deploy.ps1 -Email <verified-ses-address>` on a Windows host
- [ ] Reviewer confirms one end-to-end run produces a report email with the AI-generated narrative (exercises the new Messages API path against real Bedrock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)