### PR TITLE
fix: cleanup.sh uses wrong output key and wrong deletion order

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,11 @@ The Lambda runs synchronously, writes a CSV to the report bucket, and emails you
 ### Step 9. (Optional) Tear it all down
 
 ```bash
-./scripts/cleanup.sh --profile your-aws-profile
+./scripts/cleanup.sh --profile your-aws-profile              # interactive confirmation
+./scripts/cleanup.sh --profile your-aws-profile --yes        # non-interactive (CI/automation)
 ```
 
-Deletes the CFN stack, empties the report bucket, and removes the Lambda and EventBridge rule.
+Empties the report bucket first (CloudFormation can't delete a non-empty S3 bucket), then deletes the CFN stack and everything it owns: Lambda function, IAM role, EventBridge rule, and the bucket itself. Waits for the stack deletion to complete before exiting.
 
 ---
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -4,7 +4,8 @@ set -e
 # Configuration
 STACK_NAME="aws-access-review"
 REGION="us-east-1"  # Change to your preferred region
-AWS_PROFILE=""  # AWS profile to use
+AWS_PROFILE=""      # AWS profile to use
+SKIP_CONFIRM=false  # Skip the interactive prompt for automation
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -21,6 +22,10 @@ while [[ $# -gt 0 ]]; do
       AWS_PROFILE="$2"
       shift 2
       ;;
+    --yes|-y)
+      SKIP_CONFIRM=true
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
       exit 1
@@ -35,41 +40,47 @@ if [ -n "$AWS_PROFILE" ]; then
   echo "Using AWS profile: $AWS_PROFILE"
 fi
 
-# Confirm deletion
-echo "This will delete the CloudFormation stack '$STACK_NAME' and all associated resources."
-echo "This action cannot be undone."
-read -p "Are you sure you want to proceed? (y/n) " -n 1 -r
-echo
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-  echo "Cleanup cancelled."
-  exit 0
+# Confirm deletion (unless --yes was passed)
+if [ "$SKIP_CONFIRM" != true ]; then
+  echo "This will delete the CloudFormation stack '$STACK_NAME' and all associated resources."
+  echo "This action cannot be undone."
+  read -p "Are you sure you want to proceed? (y/n) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Cleanup cancelled."
+    exit 0
+  fi
 fi
 
-# Get S3 bucket names from the stack
-echo "Getting S3 bucket names from the stack..."
-REPORT_BUCKET=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" $AWS_CMD_PROFILE --query "Stacks[0].Outputs[?OutputKey=='ReportBucketName'].OutputValue" --output text)
+# Look up the report bucket name from the stack output BEFORE deleting the stack.
+# The CloudFormation template exposes this as output key "AccessReviewS3Bucket".
+echo "Looking up report bucket name from stack outputs..."
+REPORT_BUCKET=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" $AWS_CMD_PROFILE \
+  --query "Stacks[0].Outputs[?OutputKey=='AccessReviewS3Bucket'].OutputValue" \
+  --output text 2>/dev/null || true)
 
-# Get Lambda code bucket from the stack parameters
-CODE_BUCKET=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" $AWS_CMD_PROFILE --query "Stacks[0].Parameters[?ParameterKey=='LambdaCodeBucket'].ParameterValue" --output text)
+# Empty the S3 bucket first. CloudFormation can't delete a non-empty S3 bucket,
+# so the stack delete will fail with "BucketNotEmpty" if we skip this step.
+if [ -n "$REPORT_BUCKET" ] && [ "$REPORT_BUCKET" != "None" ]; then
+  echo "Emptying report bucket: $REPORT_BUCKET"
+  aws s3 rm "s3://$REPORT_BUCKET" --recursive --region "$REGION" $AWS_CMD_PROFILE
+else
+  echo "No report bucket found in stack outputs (already deleted or never created); skipping empty step."
+fi
 
-# Delete the CloudFormation stack
+# Delete the CloudFormation stack. The stack itself owns the bucket, so once it
+# is empty the delete-stack call cleans up the bucket + Lambda + IAM role +
+# EventBridge rule + Lambda permission in one operation.
 echo "Deleting CloudFormation stack: $STACK_NAME"
-aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION" $AWS_CMD_PROFILE
+aws cloudformation delete-stack \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" $AWS_CMD_PROFILE
 
 echo "Waiting for stack deletion to complete..."
-aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION" $AWS_CMD_PROFILE
+aws cloudformation wait stack-delete-complete \
+  --stack-name "$STACK_NAME" \
+  --region "$REGION" $AWS_CMD_PROFILE
 
-# Empty and delete S3 buckets
-if [ -n "$REPORT_BUCKET" ]; then
-  echo "Emptying and deleting report bucket: $REPORT_BUCKET"
-  aws s3 rm "s3://$REPORT_BUCKET" --recursive --region "$REGION" $AWS_CMD_PROFILE
-  aws s3 rb "s3://$REPORT_BUCKET" --region "$REGION" $AWS_CMD_PROFILE
-fi
-
-if [ -n "$CODE_BUCKET" ]; then
-  echo "Emptying and deleting Lambda code bucket: $CODE_BUCKET"
-  aws s3 rm "s3://$CODE_BUCKET" --recursive --region "$REGION" $AWS_CMD_PROFILE
-  aws s3 rb "s3://$CODE_BUCKET" --region "$REGION" $AWS_CMD_PROFILE
-fi
-
-echo "Cleanup completed successfully!" 
+echo "Cleanup completed successfully!"


### PR DESCRIPTION
## Summary

`cleanup.sh` had three independent bugs that together made it silently non-functional against the current CloudFormation template. Caught while tearing down the test stack from [PR #3](https://github.com/ajy0127/aws_automated_access_review/pull/3) — had to empty the bucket and delete the stack manually because the script did nothing useful.

1. **Wrong output key.** Script queried `Outputs[OutputKey=='ReportBucketName']` but the template exposes the bucket as `AccessReviewS3Bucket`. `REPORT_BUCKET` was always empty, so the entire S3 cleanup block was skipped.
2. **Wrong order.** Even if the lookup had worked, `delete-stack` was called **before** emptying the bucket. CloudFormation refuses to delete a non-empty S3 bucket, so the stack delete would have failed with `BucketNotEmpty`. Reordered: look up bucket name → empty it → delete the stack.
3. **Stale code-bucket reference.** Script referenced a `LambdaCodeBucket` parameter that doesn't exist in the current template. Lambda is packaged inline via `update-function-code`, not from a separate code bucket. Removed.

Also:
- Added `--yes` / `-y` to skip the interactive confirmation (CI / automation use).
- Dropped the separate `aws s3 rb` call. The stack owns the bucket resource, so once it's empty `delete-stack` cleans it up in one operation.
- README teardown section updated to show both interactive and `--yes` usage and explain the empty-then-delete ordering.

## Verified locally

- `bash -n scripts/cleanup.sh` — syntax clean.
- `flake8`, `black --check`, `cfn-lint`, `pytest tests/unit` — all clean.

## Test plan

- [ ] CI green
- [ ] Reviewer redeploys to sandbox account, generates one report, then runs `./scripts/cleanup.sh --profile <profile> --yes` and confirms the stack, bucket, Lambda, IAM role, and EventBridge rule are all gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)