### PR TITLE
fix: document deployer IAM policies + Marketplace access on Lambda role

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ Perfect for GRC professionals managing SOC 2 Type 2 and similar compliance frame
   - Amazon SES (with verified email for receiving reports)
   - Amazon Bedrock (with access to Claude model)
 
+### IAM permissions for the deploying user
+
+The identity running `scripts/deploy.sh` needs to create IAM roles, Lambda, S3, CFN, EventBridge, SES, and Bedrock resources, and subscribe to Bedrock models through Marketplace. If you hit `AccessDenied` mid-deploy, one of these is missing. The minimum set of AWS managed policies:
+
+| Policy | What it's for |
+| ------ | ------------- |
+| `AWSCloudFormationFullAccess` | Create/update the stack itself |
+| `IAMFullAccess` | Create the Lambda execution role |
+| `AWSLambda_FullAccess` | Create/update the Lambda function |
+| `AmazonS3FullAccess` | Create the report bucket |
+| `AmazonEventBridgeFullAccess` | Create the scheduled rule |
+| `AmazonSESFullAccess` | Verify the sender/recipient identity |
+| `AmazonBedrockFullAccess` | Invoke the AI model |
+| `AWSMarketplaceFullAccess` | Subscribe to third-party Bedrock models (Anthropic) |
+
+These are the AWS-managed "FullAccess" policies for simplicity. In a production account you'd usually scope each one down to just the actions and resources this tool actually uses (e.g. `cloudformation:*` limited to the stack name, `s3:*` limited to the report bucket ARN). Start with the FullAccess set to get a first deploy working, then tighten.
+
+The **Lambda execution role** created by the CloudFormation template gets its own set of permissions — you don't need to configure those separately. It attaches `AWSLambdaBasicExecutionRole` and `AWSMarketplaceFullAccess` as managed policies plus a scoped inline policy covering S3/SES/IAM read/Bedrock invoke.
+
 ## Deployment Guide
 
 End-to-end deploy takes about 10 minutes. Follow each step in order — don't skip. A PowerShell variant of step 6 is in the [Windows section](#windows-deployment) below.

--- a/templates/access-review-real.yaml
+++ b/templates/access-review-real.yaml
@@ -125,10 +125,17 @@ Resources:
               Service: lambda.amazonaws.com  # Only Lambda can use this role
             Action: sts:AssumeRole           # Allow Lambda to assume this role
       
-      # Attach AWS managed policy for basic Lambda execution
-      # This gives permission to write logs to CloudWatch
+      # Attach AWS managed policies for Lambda execution and Bedrock model invocation.
+      # - AWSLambdaBasicExecutionRole: write CloudWatch Logs
+      # - AWSMarketplaceFullAccess: required to invoke third-party Bedrock models
+      #   (e.g. Anthropic Claude) that are delivered via AWS Marketplace. Without
+      #   this, invoke_model silently returns an access error and the narrative
+      #   falls back to the non-AI fallback. Scope down to AmazonBedrockFullAccess
+      #   or minimal aws-marketplace:View*/Subscribe* actions if your threat model
+      #   requires tighter permissions.
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/AWSMarketplaceFullAccess
       
       # Custom policies for our specific permissions
       Policies:


### PR DESCRIPTION
## Summary

Addresses the IAM-permissions section (Issues 9, 10) of Tiffany's 2026-04-10 lab-fixes writeup.

### What changed

1. **Lambda execution role gets `AWSMarketplaceFullAccess`.** Anthropic Claude on Bedrock is delivered via AWS Marketplace; `invoke_model` requires the caller to have Marketplace subscription visibility or it returns an access error and the tool silently falls back to the non-AI narrative. The previous live test only worked because the invoking role was an SSO admin with implicit access — a scoped role wouldn't. Added via `ManagedPolicyArns`, with a comment explaining how to tighten down to `AmazonBedrockFullAccess` or inline `aws-marketplace:View*/Subscribe*` if your threat model requires it.

2. **README Prerequisites now lists the 8 deployer IAM policies**, with one-line rationale for each:
   - `AWSCloudFormationFullAccess`, `IAMFullAccess`, `AWSLambda_FullAccess`, `AmazonS3FullAccess`, `AmazonEventBridgeFullAccess`, `AmazonSESFullAccess`, `AmazonBedrockFullAccess`, `AWSMarketplaceFullAccess`

   Docs explicitly call out that these are FullAccess for simplicity — first-time deployers should start here, production deployers should scope each one down to the actions/resources this tool actually uses.

### Verified locally

- `cfn-lint templates/*.yaml` — clean.
- `aws cloudformation validate-template` — valid.
- `pytest tests/unit`, `flake8`, `black --check` — all clean.

### Coexists with PR #5

Windows-shell-compat PR touches different sections of README (Windows-deployment) and different scripts, so the two can merge in either order.

### Test plan

- [ ] CI green
- [ ] Reviewer with an account/identity that does **not** have marketplace access redeploys the stack and confirms the Lambda's AI narrative generation succeeds (previously would silently fall back)
- [ ] Reviewer with a scoped (non-admin) deployer identity confirms the documented 8 managed policies are sufficient to run `deploy.sh` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)